### PR TITLE
fix: Include types field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.3",
   "description": "Stream extractor for discord-player via youtube-dl",
   "main": "index.js",
+  "types": "typings/index.d.ts",
   "scripts": {
     "test": "cd test && node ."
   },


### PR DESCRIPTION
TypeScript is not picking up on the typedefs unless this field is present.