### PR TITLE
fix: make discord-player v5 compatible

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -73,7 +73,7 @@ class Downloader {
                         }
                     };
 
-                    resolve(data);
+                    resolve({ info: [data]});
                 } catch {
                     resolve(null);
                 }

--- a/src/main.js
+++ b/src/main.js
@@ -73,7 +73,7 @@ class Downloader {
                         }
                     };
 
-                    resolve({ info: [data]});
+                    resolve({ info: [data] });
                 } catch {
                     resolve(null);
                 }

--- a/src/main.js
+++ b/src/main.js
@@ -73,7 +73,7 @@ class Downloader {
                         }
                     };
 
-                    resolve({ info: [data] });
+                    resolve({ playlist: null, info: [data] });
                 } catch {
                     resolve(null);
                 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -16,7 +16,7 @@ declare module "@discord-player/downloader" {
 
     class Downloader {
         static download(url: string): Readable;
-        static getInfo(url: string): Promise<Info>;
+        static getInfo(url: string): Promise<{info: [Info]}>;
         static validate(url: string): boolean;
         static important(): boolean;
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -16,7 +16,7 @@ declare module "@discord-player/downloader" {
 
     class Downloader {
         static download(url: string): Readable;
-        static getInfo(url: string): Promise<{info: [Info]}>;
+        static getInfo(url: string): Promise<{ info: Info[] }>;
         static validate(url: string): boolean;
         static important(): boolean;
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -16,7 +16,7 @@ declare module "@discord-player/downloader" {
 
     class Downloader {
         static download(url: string): Readable;
-        static getInfo(url: string): Promise<{ info: Info[] }>;
+        static getInfo(url: string): Promise<{ playlist?: any, info: Info[] }>;
         static validate(url: string): boolean;
         static important(): boolean;
     }


### PR DESCRIPTION
Updates discord-player-downloader to reflect the ExtractorModel changes made in https://github.com/Androz2091/discord-player/commit/62bf57ac7482843d4c2694aab7794b881aa6b406#diff-2a0195201cb04efb11714b2999b4db85896c20f7acb91b5037466c86129ffedfL32-R43

Previously would successfully scrape data but wouldn't return it in the format expected by discord-player, resulting in discord-player interpreting it as null data (same as if it was given an invalid link).